### PR TITLE
Support for mobile devices (ios/android) with touch controls

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -495,12 +495,10 @@ clockStep *= 0.97;
 			hwRegisters[0x4001] = new HwRegister(null, function(val) { sweep(pulse1, val); });
 			hwRegisters[0x4005] = new HwRegister(null, function(val) { sweep(pulse2, val); });
 
-
 			hwRegisters[0x4002] = new HwRegister(null, function(val) { timer(pulse1, val); });
 			hwRegisters[0x4006] = new HwRegister(null, function(val) { timer(pulse2, val); });
 			hwRegisters[0x400A] = new HwRegister(null, function(val) { timer(triangle, val); });
 			hwRegisters[0x400E] = new HwRegister(null, noisePeriod);
-
 
 			hwRegisters[0x4003] = new HwRegister(null, function(val) { length(pulse1, val); });
 			hwRegisters[0x4007] = new HwRegister(null, function(val) { length(pulse2, val); });

--- a/audio.js
+++ b/audio.js
@@ -49,6 +49,30 @@ var NewApu = (function() {
 		if (audio || !enableAudioEmulation) return;
 		
 		audio = new AudioContext();
+
+		var buffer = audio.createBuffer(1, 1, 44100)
+		var dummy = audio.createBufferSource()
+		dummy.buffer = buffer
+		dummy.connect(audio.destination)
+		dummy.start(0)
+		dummy.disconnect()
+		
+		audio.close() // dispose old context
+		audio = new AudioContext();
+	
+
+		// Trigger a sound on IOS after a touch, which should allow us to start playing audio when the rom is ready.
+		function initializeIosSound() {
+			var oscillator = audio.createOscillator();
+			oscillator.frequency.value = 400;
+			oscillator.connect(audio.destination);
+			oscillator.start(0);
+			oscillator.stop(0.5); // TODO: Turn off this beep
+		}
+		document.addEventListener('touchend', initializeIosSound);
+		initializeIosSound();
+
+
 		//var compressor = audio.createDynamicsCompressor();
 		masterVolume = audio.createGain();
 		masterVolume.gain.setValueAtTime(masterVolumeValue, audio.currentTime);
@@ -58,7 +82,7 @@ var NewApu = (function() {
 		//compressor.connect(masterVolume);
 		//mixer.connect(masterVolume);
 		//mixer.connect(audio.destination);
-		mixer.connect(masterVolume);
+		mixer.connect(masterVolume);	   
 
 		clockStep = 1789773 / 2 / audio.sampleRate; // NES clock frequency / 2 = APU sample rate
 clockStep *= 0.97;
@@ -275,6 +299,7 @@ clockStep *= 0.97;
 			step = 0;
 		}
 		
+		// Cutting these two causes the problem to go away too
 		updatePulse(npulse1, pulse1);
 		updatePulse(npulse2, pulse2);
 		updateTriangle(ntriangle, triangle);
@@ -357,6 +382,7 @@ clockStep *= 0.97;
 		}
 		if (!triangle.haltLengthCounter) triangle.linearReload = false;
 		
+		// If these two are removed, the problem happens _MORE_OFTEN_
 		clockDivider(pulse1);
 		clockDivider(pulse2);
 		clockDivider(noise);
@@ -478,10 +504,13 @@ clockStep *= 0.97;
 			hwRegisters[0x4001] = new HwRegister(null, function(val) { sweep(pulse1, val); });
 			hwRegisters[0x4005] = new HwRegister(null, function(val) { sweep(pulse2, val); });
 
+
+			// NOTE: The pluse audio channels for some reason are causing the breakage. Triangle is NOT. Why? I don't know, stupid ios
 			hwRegisters[0x4002] = new HwRegister(null, function(val) { timer(pulse1, val); });
 			hwRegisters[0x4006] = new HwRegister(null, function(val) { timer(pulse2, val); });
 			hwRegisters[0x400A] = new HwRegister(null, function(val) { timer(triangle, val); });
 			hwRegisters[0x400E] = new HwRegister(null, noisePeriod);
+
 
 			hwRegisters[0x4003] = new HwRegister(null, function(val) { length(pulse1, val); });
 			hwRegisters[0x4007] = new HwRegister(null, function(val) { length(pulse2, val); });

--- a/audio.js
+++ b/audio.js
@@ -59,7 +59,7 @@ var NewApu = (function() {
 		//compressor.connect(masterVolume);
 		//mixer.connect(masterVolume);
 		//mixer.connect(audio.destination);
-		mixer.connect(masterVolume);	   
+		mixer.connect(masterVolume);
 
 		clockStep = 1789773 / 2 / audio.sampleRate; // NES clock frequency / 2 = APU sample rate
 clockStep *= 0.97;
@@ -285,7 +285,6 @@ clockStep *= 0.97;
 			step = 0;
 		}
 		
-		// Cutting these two causes the problem to go away too
 		updatePulse(npulse1, pulse1);
 		updatePulse(npulse2, pulse2);
 		updateTriangle(ntriangle, triangle);
@@ -375,7 +374,6 @@ clockStep *= 0.97;
 		}
 		if (!triangle.haltLengthCounter) triangle.linearReload = false;
 		
-		// If these two are removed, the problem happens _MORE_OFTEN_
 		clockDivider(pulse1);
 		clockDivider(pulse2);
 		clockDivider(noise);
@@ -498,7 +496,6 @@ clockStep *= 0.97;
 			hwRegisters[0x4005] = new HwRegister(null, function(val) { sweep(pulse2, val); });
 
 
-			// NOTE: The pluse audio channels for some reason are causing the breakage. Triangle is NOT. Why? I don't know, stupid ios
 			hwRegisters[0x4002] = new HwRegister(null, function(val) { timer(pulse1, val); });
 			hwRegisters[0x4006] = new HwRegister(null, function(val) { timer(pulse2, val); });
 			hwRegisters[0x400A] = new HwRegister(null, function(val) { timer(triangle, val); });

--- a/browsersupport.js
+++ b/browsersupport.js
@@ -1,0 +1,9 @@
+/*
+Support for features with browser prefixes and the like... fixes weird shortcomings in:
+- safari on ios
+
+*/
+
+if (!window.AudioContext && window.webkitAudioContext) {
+    window.AudioContext = window.webkitAudioContext;
+}

--- a/browsersupport.js
+++ b/browsersupport.js
@@ -1,9 +1,27 @@
 /*
-Support for features with browser prefixes and the like... fixes weird shortcomings in:
+Support for features with browser prefixes and other strange quirks... fixes weird shortcomings in:
 - safari on ios
 
 */
 
+// Safari (all versions) still prefix this for reasons unknown.. interface is the same, so just polyfill it.
 if (!window.AudioContext && window.webkitAudioContext) {
     window.AudioContext = window.webkitAudioContext;
 }
+
+// Disable the pinch-to-zoom behavior on ios. As nice as it is for reading, it's extremely easy to trigger this
+// while trying to play a game, and that ends up ruining the experience.
+document.addEventListener('gesturestart', function(e) {
+    e.preventDefault();
+    document.body.style.zoom = 1;
+});
+
+document.addEventListener('gesturechange', function(e) {
+    e.preventDefault();
+    document.body.style.zoom = 1;
+});
+
+document.addEventListener('gestureend', function(e) {
+    e.preventDefault();
+    document.body.style.zoom = 1;
+});

--- a/emulator.js
+++ b/emulator.js
@@ -486,9 +486,14 @@ include 'mappers.js';
 	detectFps();
 
 	
-	
-	
-	
+	// Initialize audio context when the user touches the screen the first time, to fix weird ios issues
+	function audioInitializer() {
+		// iOS 9
+		document.removeEventListener('touchend', audioInitializer);
+		apu.init();
+	}
+	// iOS 9
+	document.addEventListener('touchend', audioInitializer);		
 	
 	
 	

--- a/emulator.js
+++ b/emulator.js
@@ -501,6 +501,7 @@ include 'mappers.js';
 		useMouse: UseMouse,
 		isPlaying: function () { return loaded; },
 		buttonConfig: ButtonConfig,
+		controller: Controller,
 		render: renderFrame,
 		enableShader: function(shaderScript) { useGl = true; initGl(); },
 		disableShader: function() { useGl = false; initSoftRender(); }

--- a/emulator.js
+++ b/emulator.js
@@ -54,6 +54,7 @@ window.emu = (function() {
 
 <?php
 
+include 'browsersupport.js';
 include 'ppu.js';
 include 'audio.js';
 include 'input.js';

--- a/index.php
+++ b/index.php
@@ -4,6 +4,7 @@
 	<meta charset="utf-8" />
 	<title>NEZ - play NES while surfing the WWW :O</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+	<meta name="HandheldFriendly" content="true" />
 	<meta property="og:title" content="NEZ - play NES while surfing the WWW :O" />
 	<meta property="og:url" content="http://eternal.dk/emu/" />
 	<meta property="og:image" content="nez.png" />
@@ -318,9 +319,13 @@
 			color: #eee;
 		}
 
+		.portrait h2 {
+			margin: 5px auto;
+		}
+
 		.portrait .controllerDisp {
 			max-width: 98%;
-			padding: 20px 0;
+			padding: 10px 0;
 			position: relative;
 			padding-bottom: 60px;
 		}
@@ -407,7 +412,9 @@
 			-moz-user-select: none;
 			-ms-user-select: none;
 			user-select: none;
+			touch-action: manipulation;
 		}
+
 	</style>
 	<script type="text/javascript">
 		var config = {};

--- a/index.php
+++ b/index.php
@@ -296,6 +296,61 @@
 			text-align: left;
 			color: rgba(0,0,0,0.5);			
 		}
+
+		.controllerDisp {
+			max-width: 600px;
+			margin: 20px auto;
+			text-align: center;
+			color: rgba(0,0,0,0.5);
+			border: 20px solid #ccc;
+			border-radius: 20px;
+			background-color: #000;
+			padding: 40px 0;
+		}
+
+		.controllerDisp button {
+    		padding: 15px 20px;
+			appearance: none;
+			-webkit-appearance: none;
+			-moz-appearance: none;
+			background-color: #444;
+			color: #eee;
+		}
+
+		.controllerDisp > div {
+			display: inline-block;
+		}
+
+		.controllerDisp .directions {
+			width: 30%;
+		}
+
+		.controllerDisp .middle {
+			width: 30%;
+		}
+		
+		.controllerDisp .buttons {
+			width: 30%;
+		}
+
+		.controllerDisp .directions .up, .controllerDisp .directions .down {
+			display: block;
+			margin: auto;
+			width: 50%;
+		}
+
+		.controllerDisp .directions .left, .controllerDisp .directions .right {
+			display: inline-block;
+			width: 48%;
+		}
+
+		.controllerDisp .menu {
+			margin-top: 100px;
+		}
+
+		.controllerDisp .buttons {
+			margin-top: 125px;
+		}
 	</style>
 	<script type="text/javascript">
 		var config = {};
@@ -383,38 +438,62 @@
 		}
 	</script>
 	<h2>
+		<span onclick="$('.controllerDisp').toggle(); $(window).scrollTop(100000)">
+			Touch Controls <i class="fas fa-chevron-circle-down"></i>
+		</span>
+	</h2>
+	<div class="controllerDisp" style="display: none;">
+		<div class="directions">
+			<button class="up" onmousedown="emu.controller.upPressed()" onmouseup="emu.controller.upReleased()">Up</button>
+			<button class="left" onmousedown="emu.controller.leftPressed()" onmouseup="emu.controller.leftReleased()">Left</button>
+			<button class="right" onmousedown="emu.controller.rightPressed()" onmouseup="emu.controller.rightReleased()">Right</button>
+			<button class="down" onmousedown="emu.controller.downPressed()" onmouseup="emu.controller.downReleased()">Down</button>
+		</div>
+
+		<div class="middle">
+			<button class="start" onmousedown="emu.controller.startPressed()" onmouseup="emu.controller.startReleased()">Start</button>
+			<button class="select" onmousedown="emu.controller.selectPressed()" onmouseup="emu.controller.selectReleased()">Select</button>
+		</div>
+
+		<div class="buttons">
+			<button class="a" onmousedown="emu.controller.aPressed()" onmouseup="emu.controller.aReleased()">A</button>
+			<button class="b" onmousedown="emu.controller.bPressed()" onmouseup="emu.controller.bReleased()">B</button>
+		</div>
+	</div>
+
+	<h2>
 		<a href="https://twitter.com/sumez" target="_blank"><i class="fab fa-twitter-square"></i></a>
 		<a href="https://github.com/sumez/nez" target="_blank"><i class="fab fa-github-square"></i></a>
-		<span onclick="$('.text').show(); $(window).scrollTop(100000)">
-		More about NEZ <i class="fas fa-chevron-circle-down"></i>
+		<span onclick="$('.text').toggle(); $(window).scrollTop(100000)">
+			More about NEZ <i class="fas fa-chevron-circle-down"></i>
 		</span>
 	</h2>
 	<div class="text" style="display: none;">
-	This is an emulator started as a short experiment to test how feasible it even was to pull off such a thing in JavaScript, and quickly improved to support many more games and features than I thought it possibly could, but it is also still evolving.<br />
-	If you see any glaring issues with certain games, or other support you'd like me to add, feel free to <a href="https://twitter.com/sumez" target="_blank">drop me a line</a>, and I will probably bump up the priority.<br /><br />
-	~ Sumez<br />
-	<br />
-	Features currently in the pipline for the future:<br /><br />
-	<strong>Support / accuracy:</strong>
-	<ul>
-		<li>Support for less common mappers (most notably VRC6 and MMC2 I guess?)</li>
-		<li>Controller support</li>
-		<li>Improve mouse support</li>
-		<li>50hz/PAL support</li>
-		<li>Famicom Disk System support</li>
-		<li>Improve CPU/PPU cycle synchronization</li>
-		<li>All unofficial opcodes</li>
-		<li>Better CRT shaders (correct scanlines, color bleed, etc)</li>
-		<li>Debug features (<a href="?debug=1">look here</a> for some testing features, like nametable, CHR and wavetable displays)</li>
-		<li>Save states.... maaybe?</li>
-	</ul>
-	<strong>Technical improvements</strong>
-	<ul>
-		<li>Better performance across all areas (most notably PPU emulation)</li>
-		<li>Average audio samples to improve quality and smoothen out high frequent tones</li>
-		<li><s>Re-implement mappers to actually map addresses, rather than just copying data around</s> find a new way to do this without a huge performance overhead</li>
-		<li>Change PPU emulation to use actual PPU registers rather than abstract variables that don't interfer with eachother in the same way</li>
-	</ul>
+		This is an emulator started as a short experiment to test how feasible it even was to pull off such a thing in JavaScript, and quickly improved to support many more games and features than I thought it possibly could, but it is also still evolving.<br />
+		If you see any glaring issues with certain games, or other support you'd like me to add, feel free to <a href="https://twitter.com/sumez" target="_blank">drop me a line</a>, and I will probably bump up the priority.<br /><br />
+		~ Sumez<br />
+		<br />
+		Features currently in the pipline for the future:<br /><br />
+		<strong>Support / accuracy:</strong>
+		<ul>
+			<li>Support for less common mappers (most notably VRC6 and MMC2 I guess?)</li>
+			<li>Controller support</li>
+			<li>Improve mouse support</li>
+			<li>50hz/PAL support</li>
+			<li>Famicom Disk System support</li>
+			<li>Improve CPU/PPU cycle synchronization</li>
+			<li>All unofficial opcodes</li>
+			<li>Better CRT shaders (correct scanlines, color bleed, etc)</li>
+			<li>Debug features (<a href="?debug=1">look here</a> for some testing features, like nametable, CHR and wavetable displays)</li>
+			<li>Save states.... maaybe?</li>
+		</ul>
+		<strong>Technical improvements</strong>
+		<ul>
+			<li>Better performance across all areas (most notably PPU emulation)</li>
+			<li>Average audio samples to improve quality and smoothen out high frequent tones</li>
+			<li><s>Re-implement mappers to actually map addresses, rather than just copying data around</s> find a new way to do this without a huge performance overhead</li>
+			<li>Change PPU emulation to use actual PPU registers rather than abstract variables that don't interfer with eachother in the same way</li>
+		</ul>
 	</div>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -319,7 +319,7 @@
 		}
 
 		.portrait .controllerDisp {
-			max-width: 90%;
+			max-width: 98%;
 			padding: 20px 0;
 		}
 
@@ -333,6 +333,22 @@
 
 		.portrait .controllerDisp .menu {
 			margin-top: 25px;
+		}
+
+		.portrait .controllerDisp .directions {
+			width: 35%;
+		}
+
+		.portrait .controllerDisp .middle {
+			width: 25%;
+		}
+
+		.portrait .controllerDisp .buttons {
+			width: 34%;
+		}
+
+		.portrait .controllerDisp .buttons button {
+			width: 48%;
 		}
 
 		.controllerDisp > div {

--- a/index.php
+++ b/index.php
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8" />
 	<title>NEZ - play NES while surfing the WWW :O</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<meta property="og:title" content="NEZ - play NES while surfing the WWW :O" />
 	<meta property="og:url" content="http://eternal.dk/emu/" />
 	<meta property="og:image" content="nez.png" />
@@ -317,6 +318,23 @@
 			color: #eee;
 		}
 
+		.portrait .controllerDisp {
+			max-width: 90%;
+			padding: 20px 0;
+		}
+
+		.portrait .controllerDisp button {
+			padding: 8px 14px;
+		}
+
+		.portrait .controllerDisp .buttons {
+			margin-top: 30px;
+		}
+
+		.portrait .controllerDisp .menu {
+			margin-top: 25px;
+		}
+
 		.controllerDisp > div {
 			display: inline-block;
 		}
@@ -351,6 +369,16 @@
 		.controllerDisp .buttons {
 			margin-top: 125px;
 		}
+
+		.controllerDisp, .controllerDisp * {
+			/* Prevent text selection on screen-based inputs */
+			-webkit-touch-callout: none;
+			-webkit-user-select: none;
+			-khtml-user-select: none;
+			-moz-user-select: none;
+			-ms-user-select: none;
+			user-select: none;
+		}
 	</style>
 	<script type="text/javascript">
 		var config = {};
@@ -370,6 +398,13 @@
 			if (window.isDebug) return;
 			
 			var isFullscreen = ((screen.availHeight || screen.height-20) <= window.innerHeight);
+			var isPortrait = false;
+			if (screen.width < screen.height) {
+				// Probably mobile; gets its own treatment. Never fullscreen, because we need controls
+				isFullscreen = false;
+				isPortrait = true;
+			}
+
 			var canvas = $('.nes')[0];
 			var emulator = $('.emulator')[0];
 			var windowHeight = window.screen.height;
@@ -395,6 +430,7 @@
 			emulator.style.top = ((window.screen.height - height) / 2) + 'px';
 			emulator.style.left = ((window.screen.width - width) / 2) + 'px';
 			document.body.className = isFullscreen ? 'fullscreen' : '';
+			document.body.className += isPortrait ? ' portrait' : '';
 			
 			if (emu && emu.isPlaying()) emu.render(); // Refresh canvas after resize
 			else drawLogo();
@@ -444,20 +480,20 @@
 	</h2>
 	<div class="controllerDisp" style="display: none;">
 		<div class="directions">
-			<button class="up" onmousedown="emu.controller.upPressed()" onmouseup="emu.controller.upReleased()">Up</button>
-			<button class="left" onmousedown="emu.controller.leftPressed()" onmouseup="emu.controller.leftReleased()">Left</button>
-			<button class="right" onmousedown="emu.controller.rightPressed()" onmouseup="emu.controller.rightReleased()">Right</button>
-			<button class="down" onmousedown="emu.controller.downPressed()" onmouseup="emu.controller.downReleased()">Down</button>
+			<button class="up" onmousedown="emu.controller.upPressed()" ontouchstart="emu.controller.upPressed()" ontouchend="emu.controller.upReleased()" onmouseup="emu.controller.upReleased()">Up</button>
+			<button class="left" onmousedown="emu.controller.leftPressed()" ontouchstart="emu.controller.leftPressed()" ontouchend="emu.controller.leftReleased()" onmouseup="emu.controller.leftReleased()">Left</button>
+			<button class="right" onmousedown="emu.controller.rightPressed()" ontouchstart="emu.controller.rightPressed()" ontouchend="emu.controller.rightReleased()" onmouseup="emu.controller.rightReleased()">Right</button>
+			<button class="down" onmousedown="emu.controller.downPressed()" ontouchstart="emu.controller.downPressed()" ontouchend="emu.controller.downReleased()" onmouseup="emu.controller.downReleased()">Down</button>
 		</div>
 
 		<div class="middle">
-			<button class="start" onmousedown="emu.controller.startPressed()" onmouseup="emu.controller.startReleased()">Start</button>
-			<button class="select" onmousedown="emu.controller.selectPressed()" onmouseup="emu.controller.selectReleased()">Select</button>
+			<button class="select" onmousedown="emu.controller.selectPressed()" ontouchstart="emu.controller.selectPressed()" ontouchend="emu.controller.selectReleased()" onmouseup="emu.controller.selectReleased()">Select</button>
+			<button class="start" onmousedown="emu.controller.startPressed()" ontouchstart="emu.controller.startPressed()" ontouchend="emu.controller.startReleased()" onmouseup="emu.controller.startReleased()">Start</button>
 		</div>
 
 		<div class="buttons">
-			<button class="a" onmousedown="emu.controller.aPressed()" onmouseup="emu.controller.aReleased()">A</button>
-			<button class="b" onmousedown="emu.controller.bPressed()" onmouseup="emu.controller.bReleased()">B</button>
+			<button class="a" onmousedown="emu.controller.aPressed()" ontouchstart="emu.controller.aPressed()" ontouchend="emu.controller.aReleased()" onmouseup="emu.controller.aReleased()">A</button>
+			<button class="b" onmousedown="emu.controller.bPressed()" ontouchstart="emu.controller.bPressed()" ontouchend="emu.controller.bReleased()" onmouseup="emu.controller.bReleased()">B</button>
 		</div>
 	</div>
 

--- a/index.php
+++ b/index.php
@@ -321,6 +321,7 @@
 
 		.portrait h2 {
 			margin: 5px auto;
+			font-size: 1em;
 		}
 
 		.portrait .controllerDisp {
@@ -328,6 +329,8 @@
 			padding: 10px 0;
 			position: relative;
 			padding-bottom: 60px;
+			margin: 5px auto;
+			border-width: 5px;
 		}
 
 		.portrait .controllerDisp button {

--- a/index.php
+++ b/index.php
@@ -315,7 +315,7 @@
 		}
 
 		.controllerDisp button {
-    		padding: 15px 20px;
+			padding: 15px 20px;
 			appearance: none;
 			-webkit-appearance: none;
 			-moz-appearance: none;

--- a/index.php
+++ b/index.php
@@ -321,6 +321,8 @@
 		.portrait .controllerDisp {
 			max-width: 98%;
 			padding: 20px 0;
+			position: relative;
+			padding-bottom: 60px;
 		}
 
 		.portrait .controllerDisp button {
@@ -336,15 +338,26 @@
 		}
 
 		.portrait .controllerDisp .directions {
-			width: 35%;
+			width: 45%;
 		}
 
 		.portrait .controllerDisp .middle {
-			width: 25%;
+			width: 100%;
+			position: absolute;
+			bottom: 10px;
+			left: 0;
+		}
+
+		.portrait .controllerDisp .middle button {
+			width: 30%;
+			margin: 0 10px;
 		}
 
 		.portrait .controllerDisp .buttons {
-			width: 34%;
+			width: 45%;
+			margin-left: 5%;
+			position: relative;
+			top: -10px;
 		}
 
 		.portrait .controllerDisp .buttons button {

--- a/index.php
+++ b/index.php
@@ -104,7 +104,7 @@
 			<div title="Toggle TV shader (might be slow)" class="button shader" onclick="toggleShader()">
 				<img src="tv.svg">
 			</div>
-			<div title="Full screen" class="button" onclick="fullscreen()">
+			<div title="Full screen" class="button fullscreenButton" onclick="fullscreen()">
 				<img src="fullscreen.svg">
 			</div>
 		</div>
@@ -213,6 +213,10 @@
 		.controls input {
 			cursor: pointer;
 			outline: none !important;
+		}
+		/* Hide button controls that don't work on mobile devices */
+		.portrait .controls .button.fullscreenButton, .portrait .controls .button.controller {
+			display: none;
 		}
 		html {
 			height: 100%;

--- a/input.js
+++ b/input.js
@@ -183,3 +183,34 @@ function UseMouse() {
 window.document.addEventListener("mousemove", updateMousePosition, false);
 window.document.addEventListener("mousedown", function (e) { mouseButton(e.button, 1) }, false);
 window.document.addEventListener("mouseup", function (e) { mouseButton(e.button, 0) }, false);
+
+var Controller = {};
+
+function buttonPressed(button) {
+	controllers[0] |= button;
+}
+
+function buttonReleased(button) {
+	if (controllers[0] & button) {
+		controllers[0] ^= button;
+	}
+}
+
+Controller.aPressed = function() { return buttonPressed(ABUTTON); };
+Controller.aReleased = function() { return buttonReleased(ABUTTON); };
+Controller.bPressed = function() { return buttonPressed(BBUTTON); };
+Controller.bReleased = function() { return buttonReleased(BBUTTON); };
+
+Controller.selectPressed = function() { return buttonPressed(SELECT); };
+Controller.selectReleased = function() { return buttonReleased(SELECT); };
+Controller.startPressed = function() { return buttonPressed(START); };
+Controller.startReleased = function() { return buttonReleased(START); };
+
+Controller.upPressed = function() { return buttonPressed(UP); };
+Controller.upReleased = function() { return buttonReleased(UP); };
+Controller.downPressed = function() { return buttonPressed(DOWN); };
+Controller.downReleased = function() { return buttonReleased(DOWN); };
+Controller.leftPressed = function() { return buttonPressed(LEFT); };
+Controller.leftReleased = function() { return buttonReleased(LEFT); };
+Controller.rightPressed = function() { return buttonPressed(RIGHT); };
+Controller.rightReleased = function() { return buttonReleased(RIGHT); };


### PR DESCRIPTION
This adds support for mobile browsers to the emulator. (including safari on ios, and chrome on android) 

Tested against safari on an iphone 7, as well as an iphone se, and a few emulated android devices. 

I also verified it still works properly in Edge, Firefox and Chrome on desktop.

NOTE: I was unable to test debug mode, as it breaks on a gl error due to scripts not being included. (I mentioned this on discord when I started playing with this) Probably worth testing with your own setup to make sure I didn't break it!

Happy to tweak however needed to make this work for you.